### PR TITLE
Correcting an issue with the expected results of a call to update

### DIFF
--- a/MySQLAdapter.js
+++ b/MySQLAdapter.js
@@ -342,7 +342,13 @@ module.exports = (function() {
 				// Run query
 				connection.query(query, function(err, result) {
 					if (err) return cb(err);
-					cb(err, result);
+
+					//the update was successful, select the updated records
+					adapter.find(collectionName, options, function(err, models) {
+						if (err) return cb(err);
+
+						cb(err, models);
+					});
 				});
 			}, dbs[collectionName], cb);
 		},


### PR DESCRIPTION
The sails framework is expecting an array of models to be returned after a call to the update method.  See https://github.com/balderdashy/sails/issues/408.
I've updated the "update" method to call the "find" method after a successful update.  it passes the same collectionName and options to the find method in order to return the updated models.
Tested it locally and its working here.
