### PR TITLE
added config.port option in marshalConfig.  

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -572,6 +572,7 @@ module.exports = (function() {
   function marshalConfig(config) {
     return {
       host: config.host,
+      port: config.port || 3306,
       socketPath: config.socketPath || null,
       user: config.user,
       password: config.password,


### PR DESCRIPTION
You can now specify an optional  port:value,  that is different than the default (3306) port.
