### PR TITLE
In create(), only apply the result insertId when it is non-zero. Fixes p...

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -248,11 +248,16 @@ module.exports = (function() {
           if (err) return cb(err);
 
           // Build model to return
-          var model = _.extend({}, data, {
+          var model = data;
 
-            // TODO: look up the autoIncrement attribute and increment that instead of assuming `id`
-            id: result.insertId
-          });
+          // If the insertId is non-zero, an autoIncrement column was incremented to this value.
+          if (result.insertId && result.insertId !== 0) {
+               model = _.extend({}, data, {
+
+                // TODO: look up the autoIncrement attribute and increment that instead of assuming `id`
+                id: result.insertId
+              });
+          }
 
           // Build a Query Object
           var _query = new Query(dbs[collectionName].definition);


### PR DESCRIPTION
This corrects a problem where apps that  manage their own 'id' column (i.e. non-autoincrement) in a Sails model would (falsely) receive <instance>.id of zero in the create() result callback.
