### PR TITLE
if you have an error, connection is undefined.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -518,7 +518,7 @@ module.exports = (function() {
       if (err) {
         console.error("Error spawning mySQL connection:");
         console.error(err);
-        connection.end();
+        if (connection) connection.end();
         return cb(err);
       }
 


### PR DESCRIPTION
When you have a connection err, connection is undefined.  So calling connection.err() results in a stack dump.  

I simply checked to see if connection was there before calling .err().
