### PR TITLE
fix SQL syntax Error of GROUP BY after ORDER BY (mysql 5.6.13)

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -260,6 +260,20 @@ var sql = {
       queryPart += 'WHERE ' + sql.where(collectionName, options.where) + ' ';
     }
 
+    if (options.groupBy) {
+      queryPart += 'GROUP BY ';
+
+      // Normalize to array
+      if(!Array.isArray(options.groupBy)) options.groupBy = [options.groupBy];
+
+      options.groupBy.forEach(function(key) {
+        queryPart += key + ', ';
+      });
+
+      // Remove trailing comma
+      queryPart = queryPart.slice(0, -2) + ' ';
+    }
+
     if (options.sort) {
       queryPart += 'ORDER BY ';
 
@@ -280,20 +294,6 @@ var sql = {
       if(queryPart.slice(-2) === ', ') {
         queryPart = queryPart.slice(0, -2) + ' ';
       }
-    }
-
-    if (options.groupBy) {
-      queryPart += 'GROUP BY ';
-
-      // Normalize to array
-      if(!Array.isArray(options.groupBy)) options.groupBy = [options.groupBy];
-
-      options.groupBy.forEach(function(key) {
-        queryPart += key + ', ';
-      });
-
-      // Remove trailing comma
-      queryPart = queryPart.slice(0, -2) + ' ';
     }
 
     if (options.limit) {


### PR DESCRIPTION
`GROUP BY` clause should before `ORDER BY` clause in mysql v5.6, or mysql will throw Error: 

ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GROUP BY gameid LIMIT 18446744073709551610' at line 1
