### PR TITLE
support SUM(col1*col2) AS col1

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,11 +65,19 @@ utils.buildSelectStatement = function(criteria, table) {
     if (criteria.sum) {
       if(criteria.sum instanceof Array) {
         criteria.sum.forEach(function(opt){
-          query += 'SUM(' + opt + ') AS ' + opt + ', ';
+          if (opt.sum) {
+            query += 'SUM(' + opt.sum + ') AS ' + opt.as + ', ';
+          } else {
+            query += 'SUM(' + opt + ') AS ' + opt + ', ';
+          }
         });
 
       } else {
-        query += 'SUM(' + criteria.sum + ') AS ' + criteria.sum + ', ';
+        if (criteria.sum.sum) {
+          query += 'SUM(' + criteria.sum.sum + ') AS ' + criteria.sum.as + ', ';
+        } else {
+          query += 'SUM(' + criteria.sum + ') AS ' + criteria.sum + ', ';
+        }
       }
     }
 


### PR DESCRIPTION
With this patch, user can write sum clause like below:

``` javascript
Model.find()
  .where(...)
  .sum({sum: 'col1*col2', as: 'col1'})
  // OR
  .sum([{sum: 'col1*col2', as: 'col1'}, {sum: 'col3/col4', as: 'col3'}])
  .exec(function (err, models) {
    ...
  });
```
