### PR TITLE
Pick .end or .release depending on whether using connection pool.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -70,6 +70,14 @@ module.exports = (function() {
           connectionLimit: def.config.connectionLimit,
           waitForConnections: def.config.waitForConnections
         }));
+        adapter.releaseConnection = function(conn, cb) {
+          conn.release();
+          cb();
+        }
+      } else {
+        adapter.releaseConnection = function(conn, cb) {
+          conn.end(cb);
+        }
       }
 
       return cb();
@@ -538,7 +546,7 @@ module.exports = (function() {
       if (err) {
         console.error("Error spawning mySQL connection:");
         console.error(err);
-        connection.end();
+        adapter.releaseConnection(connection, function(){});
         return cb(err);
       }
 
@@ -547,11 +555,11 @@ module.exports = (function() {
         if (err) {
           console.error("Logic error in mySQL ORM.");
           console.error(err);
-          connection.end();
+          adapter.releaseConnection(connection, function(){});
           return cb && cb(err);
         }
 
-        connection.end(function(err) {
+        adapter.releaseConnection(connection, function(err) {
           if (err) {
             console.error("MySQL connection killed with error:");
             console.error(err);


### PR DESCRIPTION
This enables support for the 2.0.0 alpha versions of MySQL when using
connection pools.
