### PR TITLE
Define size of a VARCHAR column.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -84,7 +84,7 @@ var sql = {
 
   _schema: function(collectionName, attribute, attrName) {
     attrName = mysql.escapeId(attrName);
-    var type = sqlTypeCast(attribute.type);
+    var type = sqlTypeCast(attribute);
 
     // Process PK field
     if(attribute.primaryKey) {
@@ -332,12 +332,20 @@ var sql = {
 };
 
 // Cast waterline types into SQL data types
-function sqlTypeCast(type) {
+function sqlTypeCast(attr) {
+  var type = attr.type;
   type = type && type.toLowerCase();
 
   switch (type) {
-    case 'string':
-      return 'VARCHAR(255)';
+    case 'string': {
+      var size = 255; // By default.
+
+      // If attr.size is positive integer, use it as size of varchar.
+      if(!isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(attr.size) > 0))
+        size = attr.size;
+
+      return 'VARCHAR(' + size + ')';
+    }
 
     case 'text':
     case 'array':


### PR DESCRIPTION
String type was converted to VARCHAR(255) by default previously. Now
set size of VARCHAR defined in model file.
