### PR TITLE
making update statement return empty result set when criteria would affect 0 rows

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -429,6 +429,11 @@ module.exports = (function() {
         connection.query(query, function(err, results) {
           if(err) return cb(err);
 
+          // update statement will affect 0 rows
+          if (results.length === 0) {
+            return cb(null, []);
+          }
+
           var pks = [];
 
           results.forEach(function(result) {


### PR DESCRIPTION
this change is to fix #70.

The corresponding test for the waterline-adapter-tests project would go in lib/collection/update.test.js somewhere inside the describe('attributes') block (so that it has some test data to run against)

``` js
describe('when querying with params that will not match any records', function () {
  it('should not return an error and return an empty result set', function (done) {
    User.update('somenonexistantid', { type: 'invalid update' }, function (err, users) {
      assert(!err);
      assert(users.length === 0);
      done();
    });
  });
});
```
