### PR TITLE
allow mysql timezone setting in adapter config

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -614,7 +614,8 @@ module.exports = (function() {
       socketPath: config.socketPath || null,
       user: config.user,
       password: config.password,
-      database: config.database
+      database: config.database,
+      timezone: config.timezone || 'Z'
     };
   }
 


### PR DESCRIPTION
In order to use custom timezones when writing local dates to the database, the adapter configuration takes an optional `timezone` parameter (defaults to `Z`) as recommended by semy.
