### PR TITLE
Only supply LIMIT hack when necessary.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -299,13 +299,14 @@ var sql = {
 
     if (options.limit) {
       queryPart += 'LIMIT ' + options.limit + ' ';
-    } else {
-      // Some MySQL hackery here.  For details, see:
-      // http://stackoverflow.com/questions/255517/mysql-offset-infinite-rows
-      queryPart += 'LIMIT 18446744073709551610 ';
     }
 
     if (options.skip) {
+      // Some MySQL hackery here.  For details, see:
+      // http://stackoverflow.com/questions/255517/mysql-offset-infinite-rows
+      if (!options.limit) {
+          queryPart += 'LIMIT 18446744073709551610 ';
+      }
       queryPart += 'OFFSET ' + options.skip + ' ';
     }
 


### PR DESCRIPTION
The hack of supplying a LIMIT of maximum BIGINT is only necessary when
an OFFSET is specified. This patch avoids the hack when it isn't needed,
since it just creates noise and confusion in the SQL logs.
