### PR TITLE
Error: Schema definition missing for table @v0.10

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -137,7 +137,7 @@ module.exports = (function() {
             var normalizedSchema = sql.normalizeSchema(schema);
 
             // Set Internal Schema Mapping
-            collection.schema = normalizedSchema;
+            collection.definition = normalizedSchema;
 
             // TODO: check that what was returned actually matches the cache
             cb(null, normalizedSchema);
@@ -393,7 +393,7 @@ module.exports = (function() {
 
         // Build a copy of the schema to send w/ the query
         var localSchema = _.reduce(connectionObject.collections, function (localSchema, collection, cid) {
-          localSchema[cid] = collection.schema;
+          localSchema[cid] = collection.definition;
           return localSchema;
         }, {});
 
@@ -477,7 +477,7 @@ module.exports = (function() {
         var schema = {};
 
         Object.keys(connectionObject.collections).forEach(function(coll) {
-          schema[coll] = connectionObject.collections[coll].schema;
+          schema[coll] = connectionObject.collections[coll].definition;
         });
 
         var query = sql.selectQuery(tableName, options, schema);


### PR DESCRIPTION
I try to use the Sails.js@v0.10 

When I create model with `$ sails generate api user` 
And fill User model attributes
And lift sails
And open http://localhost:1337/user/

Then sails instance crushed with exception:

```
< Error: Schema definition missing for table: `user`
<     at Object.utils.buildSelectStatement (/x/node_modules/sails-mysql/lib/utils.js:131:35)
<     at Object.module.exports.selectQuery (/x/node_modules/sails-mysql/lib/sql.js:70:23)
<     at __FIND__ (/x/node_modules/sails-mysql/lib/adapter.js:402:25)
<     at afterwards (/x/node_modules/sails-mysql/lib/connections/spawn.js:85:5)
<     at /x/node_modules/sails-mysql/lib/connections/spawn.js:39:7
<     at Pool.getConnection (/x/node_modules/sails-mysql/node_modules/mysql/lib/Pool.js:53:14)
<     at Handshake.Sequence.end (/x/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Sequence.js:78:24)
<     at Handshake.Sequence.OkPacket (/x/node_modules/sails-mysql/node_modules/mysql/lib/protocol/sequences/Sequence.js:87:8)
<     at Protocol._parsePacket (/x/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Protocol.js:197:24)
<     at Parser.write (/x/node_modules/sails-mysql/node_modules/mysql/lib/protocol/Parser.js:62:12)
```

It seems the property of collection object named 'definition' instead 'schema' now https://github.com/balderdashy/waterline/blob/v0.10/lib/waterline.js#L162

With patch it works for me.
