### PR TITLE
Add support for defining a port when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default settings are:
 ```javascript
 {
   host: process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost',
-  port: process.env.WATERLINE_ADAPTER_TESTS_PORT || '3306',
+  port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
   user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
   password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
   database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -68,7 +68,7 @@ new TestRunner({
   // Default connection config to use.
   config: {
     host: process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost',
-    port: process.env.WATERLINE_ADAPTER_TESTS_PORT || '3306',
+    port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
     user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
     password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
     database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',


### PR DESCRIPTION
Environment variable: WATERLINE_ADAPTER_TESTS_PORT
Defaults to 3306
