### PR TITLE
Removing unnecessary config modifications

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -87,10 +87,7 @@ module.exports = (function() {
 
       // Create a Connection Pool if set
       if (def.config.pool) {
-        adapter.pool = mysql.createPool(_.extend(marshalConfig(def.config), {
-          connectionLimit: def.config.connectionLimit,
-          waitForConnections: def.config.waitForConnections
-        }));
+        adapter.pool = mysql.createPool(def.config);
       }
 
       return cb();
@@ -544,7 +541,7 @@ module.exports = (function() {
 
     // Use a new connection each time
     if (!config.pool) {
-      var connection = mysql.createConnection(marshalConfig(config));
+      var connection = mysql.createConnection(config);
       connection.connect(function(err) {
         afterwards(err, connection);
       });
@@ -602,26 +599,12 @@ module.exports = (function() {
       console.error(err);
 
 
-      connection = mysql.createConnection(marshalConfig(config));
+      connection = mysql.createConnection(config);
       connection.connect();
       // connection = mysql.createConnection(connection.config);
       // handleDisconnect(connection);
       // connection.connect();
     });
-  }
-
-  // Convert standard adapter config
-  // into a custom configuration object for node-mysql
-  function marshalConfig(config) {
-    return {
-      host: config.host,
-      port: config.port || 3306,
-      socketPath: config.socketPath || null,
-      user: config.user,
-      password: config.password,
-      database: config.database,
-      timezone: config.timezone || 'Z'
-    };
   }
 
   return adapter;


### PR DESCRIPTION
Since @felixge/node-mysql manages the required configurations
itself, there is no need to truncate config on the sails-mysql
side

https://github.com/felixge/node-mysql/blob/v2.0.0-alpha8/lib/ConnectionConfig.js
