### PR TITLE
changed a return to return cb(null)

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -502,7 +502,10 @@ module.exports = (function() {
           var pk = 'id';
 
           Object.keys(collection.definition).forEach(function(key) {
-            if(!collection.definition[key].hasOwnProperty('primaryKey')) return;
+            if(!collection.definition[key].hasOwnProperty('primaryKey')) {
+              return cb(null);
+            }
+
             pk = key;
           });
 
@@ -552,7 +555,7 @@ module.exports = (function() {
                 values.push(_query.cast(item));
               });
 
-              cb(err, values);
+              return cb(err, values);
             });
           });
 


### PR DESCRIPTION
Hey,

this commit seems to fix the bug described here. https://github.com/balderdashy/waterline/issues/282

I only checked the update method. If the save method does not rely on the update method there may be another bug there, but they look very similar to me.

I got this (small) fix working in my code, but u still might want to ram it through the test machinery just to be sure it does not break anything i dont know about.

Hope this helps. 
Kind Regards
