### PR TITLE
primary, auto_incrementing keys should be unsigned.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1,4 +1,3 @@
-
 /**
  * Module Dependencies
  */
@@ -93,7 +92,7 @@ var sql = module.exports = {
 
       // If type is an integer, set auto increment
       if(type === 'INT') {
-        return attrName + ' ' + type + ' NOT NULL AUTO_INCREMENT PRIMARY KEY';
+        return attrName + ' ' + type + ' UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
       }
 
       // Just set NOT NULL on other types


### PR DESCRIPTION
when auto incremented primary keys are created, set to unsigned. Ever heard of a negative primary key?
