### PR TITLE
Use LONGTEXT instead of TEXT

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -475,7 +475,7 @@ function sqlTypeCast(attr) {
     case 'text':
     case 'array':
     case 'json':
-      return 'TEXT';
+      return 'LONGTEXT';
 
     case 'mediumtext':
       return 'mediumtext';
@@ -505,7 +505,7 @@ function sqlTypeCast(attr) {
 
     default:
       console.error('Unregistered type given: ' + type);
-      return 'TEXT';
+      return 'LONGTEXT';
   }
 }
 


### PR DESCRIPTION
Map the 'text', 'array', and 'json' types to LONGTEXT to avoid the 64kB size limit of the TEXT datatype in MySQL.
