### PR TITLE
Correctly cast BIT columns to true or false

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -46,6 +46,9 @@ Query.prototype.cast = function(values) {
     // Convert booleans back to true/false
     if(type === 'boolean') {
       var val = values[key];
+      if (Buffer.isBuffer(val)) {
+        val = val[0];
+      }
       if(val === 0) _values[key] = false;
       if(val === 1) _values[key] = true;
     }


### PR DESCRIPTION
This fixes a bug where if a table containing columns of type BIT (acting as a boolean) was queried, a Buffer object (either &lt;Buffer 00&gt; or &lt;Buffer 01&gt;) would be returned rather than true or false.