### PR TITLE
fix for - ReferenceError: query is not defined

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -834,7 +834,7 @@ module.exports = (function() {
 
         // Run query
         if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',query);
+          console.log('\nExecuting MySQL query: ', _query.query);
         }
 
         connection.query(_query.query[0], function(err, result) {


### PR DESCRIPTION
Error occurs when we set [`LOG_QUERIES`](https://github.com/balderdashy/sails-mysql/blob/1282892650ee6b1c9f177c1eddc53eeb6b034c12/lib/adapter.js#L34) as `true`