### PR TITLE
SQL Injection fix: Validate sortKey name in order.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -707,18 +707,29 @@ module.exports = (function() {
 
                   // Add a final sort to the Union clause for integration
                   if(parentRecords.length > 1) {
-                    qs += ' ORDER BY ';
+                    var addedOrder = false;
+
+                    function addSort(sortKey, sorts) {
+                        if (!sortKey.match(/^[0-9,a-z,A-Z$_]+$/)) {
+                          return;
+                        }
+                        if (!addedOrder) {
+                          addedOrder = true;
+                          qs += ' ORDER BY ';
+                        }
+
+                        var direction = sorts[sortKey] === 1 ? 'ASC' : 'DESC';
+                        qs += sortKey + ' ' + direction;
+                    }
 
                     if(!Array.isArray(q.instructions)) {
                       _.keys(q.instructions.criteria.sort).forEach(function(sortKey) {
-                        var direction = q.instructions.criteria.sort[sortKey] === 1 ? 'ASC' : 'DESC';
-                        qs += sortKey + ' ' + direction;
+                        addSort(sortKeym, q.instructions.criteria.sort);
                       });
                     }
                     else if(q.instructions.length === 2) {
                       _.keys(q.instructions[1].criteria.sort).forEach(function(sortKey) {
-                        var direction = q.instructions[1].criteria.sort[sortKey] === 1 ? 'ASC' : 'DESC';
-                        qs += sortKey + ' ' + direction;
+                        addSort(sortKeym, q.instructions[1].criteria.sort);
                       });
                     }
                   }


### PR DESCRIPTION
Regarding #147, validate sortKey names to be valid MySQL columns based on MySQL's [identifier rules](http://dev.mysql.com/doc/refman/5.0/en/identifiers.html).

Unit tests pass.
