### PR TITLE
use type specified for primary key

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -87,7 +87,7 @@ var sql = module.exports = {
       }
 
       // Just set NOT NULL on other types
-      return attrName + ' VARCHAR(255) NOT NULL PRIMARY KEY';
+      return attrName + ' ' + type + ' NOT NULL PRIMARY KEY';
     }
 
     // Process NOT NULL field.


### PR DESCRIPTION
Right now it's assuming VARCHAR(255) for type other than INT for the primary key. This is preventing the usage of VARCHAR for primary keys when using utf8mb4 since it's limited to 191 characters or less.