### PR TITLE
Add the query in MySQL exceptions

### DIFF
--- a/lib/connections/spawn.js
+++ b/lib/connections/spawn.js
@@ -80,17 +80,18 @@ module.exports = function spawnConnection (connectionObject, fn, cb__spawnConnec
 
     /**
      * Runs a query on a connection, adding metadata to the error nicely :)
-     * @param  {Object} connection
+     * @param  {String} statement
      */
     var oldQuery = liveConnection.query;
-    liveConnection.query = function (query) {
+    liveConnection.query = function (statement) {
       // Turn the arguments into a usable array
       var args = [].slice.call(arguments);
+
       // Remove the callback that's there currently, then wrap it with
       // our own which populates the original query.
       var cb = args.pop();
       args.push(function (err) {
-        if (err) err.query = query;
+        if (err) err.query = statement;
         cb.apply(this, arguments);
       });
 
@@ -104,7 +105,7 @@ module.exports = function spawnConnection (connectionObject, fn, cb__spawnConnec
 
       // Handle errors passed back from our adapter logic.
       if (err) {
-        
+
         // Release the connection, then pass control back to Waterline core.
         connectionObject.connection.releaseConnection(liveConnection, function sendBackError ( /* thisErrDoesntMatter */ ) {
           cb__spawnConnection(err);


### PR DESCRIPTION
It's rather annoying to debug invalid queries as it stands - we have to manually turn on `LOG_QUERIES` and watch the console output (which often won't be a viable option in production). I added a "wrapper" around the default connection query, which adds the original query to the exception before being passed to the callback. Makes things much easier!

![](http://puu.sh/cXSQQ/45d987a938.png)
