### PR TITLE
Update mysql package version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "lodash": "~2.4.1",
-    "mysql": "~2.5.4",
+    "mysql": "~2.6.1",
     "waterline-errors": "~0.10.0",
     "waterline-sequel": "~0.1.1",
     "waterline-cursor": "~0.0.5"


### PR DESCRIPTION
Updates to ~2.6.1, fixing #203 .  According to [the changelog](https://github.com/felixge/node-mysql/blob/master/Changes.md) there shouldn't be any compatibility issues or breaking changes, and sails-mysql still passes all tests on from waterline-adapter-tests edge.