### PR TITLE
Added support for BIGINT, TINYINT and SMALLINT.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ssl
 nbproject
 .waterline
 npm-debug.log
+.c9

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "0.10"
 services: mysql
 before_script:
-  - mysql -e 'create database sails_unitTest;'
+  - mysql -e 'create database sails_mysql;'
 notifications:
   email:
     - particlebanana@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "0.10"
 services: mysql
 before_script:
-  - mysql -e 'create database sails_mysql;'
+  - mysql -e 'create database sails_unitTest;'
 notifications:
   email:
     - particlebanana@gmail.com

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MOCHA_OPTS= --check-leaks
 REPORTER = dot
 
-test: test-integration
+test: test-unit test-integration
 
 test-integration:
 	@NODE_ENV=test node test/integration/runner.js
@@ -11,3 +11,9 @@ test-load:
 		--reporter $(REPORTER) \
 		$(MOCHA_OPTS) \
 		test/load/**
+
+test-unit:
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+		--reporter $(REPORTER) \
+		$(MOCHA_OPTS) \
+		test/unit/**

--- a/lib/connections/teardown.js
+++ b/lib/connections/teardown.js
@@ -21,7 +21,8 @@ module.exports.configure = function ( connections ) {
     function closeConnection(name) {
       // Drain the MySQL connection pool for this Waterline Connection
       // (if it's in use.)
-      if ( connections[name].connection.pool ) {
+
+      if ( connections[name] && connections[name].connection && connections[name].connection.pool ) {
         // console.log('Ending pool for ' + connectionName);
         connections[name].connection.pool.end();
       }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -82,8 +82,8 @@ var sql = module.exports = {
     if(attribute.primaryKey) {
 
       // If type is an integer, set auto increment
-      if(type === 'INT') {
-        return attrName + ' INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
+      if(type === 'TINYINT' || type === 'SMALLINT' || type === 'INT' || type === 'BIGINT') {
+        return attrName + ' ' + type + ' UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
       }
 
       // Just set NOT NULL on other types
@@ -358,7 +358,7 @@ function sqlTypeCast(attr) {
       var size = 255; // By default.
 
       // If attr.size is positive integer, use it as size of varchar.
-      if(!isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(attr.size) > 0))
+      if(!Number.isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(attr.size) > 0))
         size = attr.size;
 
       return 'VARCHAR(' + size + ')';
@@ -379,8 +379,29 @@ function sqlTypeCast(attr) {
       return 'BOOL';
 
     case 'int':
-    case 'integer':
-      return 'INT';
+    case 'integer': {
+      var size = 32; // By default
+      
+      if(!Number.isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(size) > 0)) {
+        size = attr.size;
+      }
+      
+      // MEDIUMINT gets internally promoted to INT so there is no real benefit
+      // using it.
+      
+      switch (size) {
+        case 8:
+          return 'TINYINT';
+        case 16:
+          return 'SMALLINT';
+        case 32:
+          return 'INT';
+        case 64:
+          return 'BIGINT'
+        default:
+          return 'INT';
+      }
+    }
 
     case 'float':
     case 'double':

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -383,7 +383,7 @@ function sqlTypeCast(attr) {
       var size = 32; // By default
       
       if(!Number.isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(size) > 0)) {
-        size = attr.size;
+        size = parseInt(attr.size);
       }
       
       // MEDIUMINT gets internally promoted to INT so there is no real benefit

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -350,7 +350,13 @@ var sql = module.exports = {
 
 // Cast waterline types into SQL data types
 function sqlTypeCast(attr) {
-  var type = attr.type;
+  var type;
+  if(_.isObject(attr) && _.has(attr, 'type')) {
+    type = attr.type; 
+  } else {
+    type = attr;
+  }
+  
   type = type && type.toLowerCase();
 
   switch (type) {
@@ -406,6 +412,9 @@ function sqlTypeCast(attr) {
     case 'float':
     case 'double':
       return 'FLOAT';
+    
+    case 'decimal':
+      return 'DECIMAL';
 
     case 'date':
       return 'DATE';

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "waterline-cursor": "~0.0.5"
   },
   "devDependencies": {
+    "should": "*",
     "mocha": "~1.13.0",
     "waterline-adapter-tests": "~0.10.7",
     "captains-log": "~0.11.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mysql",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "MySQL adapter for Sails.js",
   "main": "lib/adapter.js",
   "scripts": {

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -73,7 +73,7 @@ new TestRunner({
     port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
     user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
     password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
-    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_unitTest',
+    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',
     pool: true,
     connectionLimit: 10,
     queueLimit: 0,

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -40,7 +40,7 @@ try {
 
 
 
-log.info('Testing `' + packageDefinition.name + '`, a Sails/Waterline adapter.');
+log.info('Testing `' + package.name + '`, a Sails/Waterline adapter.');
 log.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
 log.info('( ' + interfaces.join(', ') + ' )');
 console.log();
@@ -73,7 +73,7 @@ new TestRunner({
     port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
     user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
     password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
-    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_loadTest',
+    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',
     pool: true,
     connectionLimit: 10,
     queueLimit: 0,

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -73,7 +73,7 @@ new TestRunner({
     port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
     user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
     password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
-    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',
+    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_unitTest',
     pool: true,
     connectionLimit: 10,
     queueLimit: 0,

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -40,7 +40,7 @@ try {
 
 
 
-log.info('Testing `' + package.name + '`, a Sails/Waterline adapter.');
+log.info('Testing `' + packageDefinition.name + '`, a Sails/Waterline adapter.');
 log.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
 log.info('( ' + interfaces.join(', ') + ' )');
 console.log();
@@ -73,7 +73,7 @@ new TestRunner({
     port: process.env.WATERLINE_ADAPTER_TESTS_PORT || 3306,
     user: process.env.WATERLINE_ADAPTER_TESTS_USER || 'root',
     password: process.env.WATERLINE_ADAPTER_TESTS_PASSWORD || '',
-    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_mysql',
+    database: process.env.WATERLINE_ADAPTER_TESTS_DATABASE || 'sails_loadTest',
     pool: true,
     connectionLimit: 10,
     queueLimit: 0,

--- a/test/load/loadTest.js
+++ b/test/load/loadTest.js
@@ -13,7 +13,7 @@ describe('Load Testing', function() {
     var Schema;
 
     // Register The Collection
-    Adapter.registerCollection({ identity: 'loadTest', config: Config }, function(err) {
+    Adapter.registerConnection({ identity: 'loadTest', config: Config }, {'Person': Fixture}, function(err) {
       if(err) done(err);
 
       // Define The Collection

--- a/test/load/support/bootstrap.js
+++ b/test/load/support/bootstrap.js
@@ -17,7 +17,7 @@ after(function(done) {
 });
 
 function dropTable(cb) {
-  Adapter.registerCollection({ identity: 'loadTest', config: config }, function(err) {
+  Adapter.registerConnection({ identity: 'loadTest', config: config }, function(err) {
     if(err) cb(err);
     Adapter.drop('loadTest', cb);
   });

--- a/test/load/support/config.js
+++ b/test/load/support/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   host: 'localhost',
-  user: 'sixpounder',
+  user: 'root',
   password: '',
   database: 'sails_loadTest',
   pool: true,

--- a/test/load/support/config.js
+++ b/test/load/support/config.js
@@ -1,8 +1,8 @@
 module.exports = {
   host: 'localhost',
-  user: 'root',
+  user: 'sixpounder',
   password: '',
-  database: 'sails-loadTest',
+  database: 'sails_loadTest',
   pool: true,
   connectionLimit: 10,
   waitForConnections: true

--- a/test/load/support/fixture.js
+++ b/test/load/support/fixture.js
@@ -9,6 +9,7 @@ module.exports = {
   id:{
     type: 'integer',
     autoIncrement: true,
+    size: 64,
     defaultsTo: 'AUTO_INCREMENT',
     primaryKey: true
   },

--- a/test/unit/adapter.addAttribute.js
+++ b/test/unit/adapter.addAttribute.js
@@ -1,0 +1,46 @@
+var adapter = require('../../lib/adapter'),
+    _ = require('lodash'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_addAttribute', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_addAttribute', done);
+  });
+
+  /**
+   * ADD ATTRIBUTE
+   *
+   * Adds a column to a Table
+   */
+
+  describe('.addAttribute()', function() {
+
+    // Add a column to a table
+    it('should add column color to the table', function(done) {
+
+      adapter.addAttribute('test', 'test_addAttribute', 'color', 'string', function(err, result) {
+        adapter.describe('test', 'test_addAttribute', function(err, result) {
+
+          // Test Row length
+          Object.keys(result).length.should.eql(4);
+
+          // Test the name of the last column
+          should.exist(result.color);
+
+          done();
+        });
+      });
+
+    });
+  });
+});

--- a/test/unit/adapter.avg.js
+++ b/test/unit/adapter.avg.js
@@ -1,0 +1,58 @@
+var Sequel = require('waterline-sequel'),
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * AVG
+   *
+   * Adds a AVG select parameter to a sql statement
+   */
+
+  describe('.avg()', function() {
+
+    describe('with array', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        average: ['age']
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the AVG aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT CAST( AVG("test"."age") AS float) AS age FROM "test" AS "test"  WHERE ' +
+                  'LOWER("test"."name") = $1 ';
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+    describe('with string', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        average: 'age'
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the AVG aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT CAST( AVG("test"."age") AS float) AS age FROM "test" AS "test"  WHERE ' +
+                  'LOWER("test"."name") = $1 ';
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.create.js
+++ b/test/unit/adapter.create.js
@@ -1,0 +1,82 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_create', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_create', done);
+  });
+
+  // Attributes for the test table
+  var attributes = {
+    field_1: 'foo',
+    field_2: 'bar'
+  };
+
+  /**
+   * CREATE
+   *
+   * Insert a row into a table
+   */
+
+  describe('.create()', function() {
+
+    // Insert a record
+    it('should insert a single record', function(done) {
+      adapter.create('test', 'test_create', attributes, function(err, result) {
+
+        // Check record was actually inserted
+        support.Client(function(err, client, close) {
+          client.query('SELECT * FROM test_create', function(err, rows) {
+            if (err) {
+              return done(err);
+            }
+            // Test 1 row is returned
+            rows.length.should.eql(1);
+
+            // close client
+            client.end();
+
+            done();
+          });
+        });
+      });
+    });
+
+    // Create Auto-Incremented ID
+    it('should create an auto-incremented ID field', function(done) {
+      adapter.create('test', 'test_create', attributes, function(err, result) {
+
+        // Should have an ID of 2
+        result.id.should.eql(2);
+
+        done();
+      });
+    });
+
+    it('should keep case', function(done) {
+      var attributes = {
+        field_1: 'Foo',
+        field_2: 'bAr'
+      };
+
+      adapter.create('test', 'test_create', attributes, function(err, result) {
+
+        result.field_1.should.eql('Foo');
+        result.field_2.should.eql('bAr');
+
+        done();
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.createEach.js
+++ b/test/unit/adapter.createEach.js
@@ -1,0 +1,54 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_createEach', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_createEach', done);
+  });
+
+  // Attributes for the test table
+  var attributes = {
+    field_1: 'foo',
+    field_2: 'bar'
+  };
+
+  /**
+   * CREATE EACH
+   *
+   * Insert an array of rows into a table
+   */
+
+  describe('.createEach()', function() {
+
+    // Insert multiple records
+    it('should insert multiple records', function(done) {
+      adapter.createEach('test', 'test_createEach', [attributes, attributes], function(err, result) {
+
+        // Check records were actually inserted
+        support.Client(function(err, client) {
+          client.query('SELECT * FROM test_createEach', function(err, rows) {
+
+            // Test 2 rows are returned
+            rows.length.should.eql(2);
+
+            // close client
+            client.end();
+
+            done();
+          });
+        });
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -61,7 +61,7 @@ describe('adapter', function() {
       });
 
       // notNull constraint
-      it('should add a notNull constraint', function(done) {
+      it('should create a bigint primary key', function(done) {
         adapter.define('test', 'test_define', definition, function(err) {
           support.Client(function(err, client) {
             var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
@@ -78,7 +78,7 @@ describe('adapter', function() {
 
     });
     
-    it('should create a bigint primary key', function(done) {
+    it('should add a notNull constraint', function(done) {
         adapter.define('test', 'test_define', definition, function(err) {
           support.Client(function(err, client) {
             var query = "SELECT IS_NULLABLE from information_schema.COLUMNS "+

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -1,0 +1,126 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.registerConnection(['test_define', 'user'], done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_define', done);
+  });
+
+  // Attributes for the test table
+  var definition = {
+    id    : {
+      type: 'integer',
+      size: 64,
+      autoIncrement: true
+    },
+    name  : {
+      type: 'string',
+      notNull: true
+    },
+    email : 'string',
+    title : 'string',
+    phone : 'string',
+    type  : 'string',
+    favoriteFruit : {
+      defaultsTo: 'blueberry',
+      type: 'string'
+    },
+    age   : 'integer'
+  };
+
+  /**
+   * DEFINE
+   *
+   * Create a new table with a defined set of attributes
+   */
+
+  describe('.define()', function() {
+
+    describe('basic usage', function() {
+
+      // Build Table from attributes
+      it('should build the table', function(done) {
+
+        adapter.define('test', 'test_define', definition, function(err) {
+          adapter.describe('test', 'test_define', function(err, result) {
+            Object.keys(result).length.should.eql(8);
+            done();
+          });
+        });
+
+      });
+
+      // notNull constraint
+      it('should add a notNull constraint', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = 'sails_unitTest' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'id'";
+            
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("bigint(20)");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+
+    });
+    
+    it('should create a bigint primary key', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT IS_NULLABLE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = 'sails_unitTest' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'name'";
+            
+            client.query(query, function(err, rows) {
+              rows[0].IS_NULLABLE.should.eql("NO");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+
+    describe('reserved words', function() {
+
+      after(function(done) {
+        support.Client(function(err, client) {
+          var query = 'DROP TABLE user;';
+          client.query(query, function(err) {
+
+            // close client
+            client.end();
+
+            done();
+          });
+        });
+      });
+
+      // Build Table from attributes
+      it('should escape reserved words', function(done) {
+
+        adapter.define('test', 'user', definition, function(err) {
+          adapter.describe('test', 'user', function(err, result) {
+            Object.keys(result).length.should.eql(8);
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+});

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -65,7 +65,7 @@ describe('adapter', function() {
         adapter.define('test', 'test_define', definition, function(err) {
           support.Client(function(err, client) {
             var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
-              "WHERE TABLE_SCHEMA = 'sails_unitTest' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'id'";
+              "WHERE TABLE_SCHEMA = 'sails_mysql' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'id'";
             
             client.query(query, function(err, rows) {
               rows[0].COLUMN_TYPE.should.eql("bigint(20)");
@@ -82,7 +82,7 @@ describe('adapter', function() {
         adapter.define('test', 'test_define', definition, function(err) {
           support.Client(function(err, client) {
             var query = "SELECT IS_NULLABLE from information_schema.COLUMNS "+
-              "WHERE TABLE_SCHEMA = 'sails_unitTest' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'name'";
+              "WHERE TABLE_SCHEMA = 'sails_mysql' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'name'";
             
             client.query(query, function(err, rows) {
               rows[0].IS_NULLABLE.should.eql("NO");

--- a/test/unit/adapter.describe.js
+++ b/test/unit/adapter.describe.js
@@ -1,0 +1,42 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_describe', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_describe', done);
+  });
+
+  /**
+   * DESCRIBE
+   *
+   * Similar to MySQL's Describe method this should list the
+   * properties of a table.
+   */
+
+  describe('.describe()', function() {
+
+    // Output Column Names
+    it('should output the column names', function(done) {
+      adapter.describe('test', 'test_describe', function(err, results) {
+        Object.keys(results).length.should.eql(3);
+
+        should.exist(results.id);
+        should.exist(results.field_1);
+        should.exist(results.field_2);
+
+        done();
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.destroy.js
+++ b/test/unit/adapter.destroy.js
@@ -1,0 +1,55 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_destroy', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_destroy', done);
+  });
+
+  /**
+   * DESTROY
+   *
+   * Remove a row from a table
+   */
+
+  describe('.destroy()', function() {
+
+    describe('with options', function() {
+
+      before(function(done) {
+        support.Seed('test_destroy', done);
+      });
+
+      it('should destroy the record', function(done) {
+        adapter.destroy('test', 'test_destroy', { where: { id: 1 }}, function(err, result) {
+
+          // Check record was actually removed
+          support.Client(function(err, client) {
+            client.query('SELECT * FROM test_destroy', function(err, rows) {
+
+              // Test no rows are returned
+              rows.length.should.eql(0);
+
+              // close client
+              client.end();
+
+              done();
+            });
+          });
+
+        });
+      });
+
+    });
+  });
+});

--- a/test/unit/adapter.drop.js
+++ b/test/unit/adapter.drop.js
@@ -1,0 +1,39 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_drop', done);
+  });
+
+  after(function(done) {
+    adapter.teardown('test', done);
+  });
+
+  /**
+   * DROP
+   *
+   * Drop a table and all it's records.
+   */
+
+  describe('.drop()', function() {
+
+    // Drop the Test table
+    it('should drop the table', function(done) {
+
+      adapter.drop('test', 'test_drop', function(err, result) {
+        adapter.describe('test', 'test_drop', function(err, result) {
+          should.not.exist(result);
+          done();
+        });
+      });
+
+    });
+  });
+});

--- a/test/unit/adapter.find.js
+++ b/test/unit/adapter.find.js
@@ -1,0 +1,87 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_find', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_find', done);
+  });
+
+  /**
+   * FIND
+   *
+   * Returns an array of records from a SELECT query
+   */
+
+  describe('.find()', function() {
+
+    describe('WHERE clause', function() {
+
+      before(function(done) {
+        support.Seed('test_find', done);
+      });
+
+      describe('key/value attributes', function() {
+
+        it('should return the record set', function(done) {
+          adapter.find('test', 'test_find', { where: { field_1: 'foo' } }, function(err, results) {
+            results.length.should.eql(1);
+            results[0].id.should.eql(1);
+            done();
+          });
+        });
+
+      });
+
+      describe('comparators', function() {
+
+        // Insert a unique record to test with
+        before(function(done) {
+          var query = [
+            'INSERT INTO test_find (field_1, field_2)',
+            "values ('foobar', 'AR)H$daxx');"
+          ].join('');
+
+          support.Client(function(err, client) {
+            client.query(query, function() {
+
+              // close client
+              client.end();
+
+              done();
+            });
+          });
+        });
+
+        it('should support endsWith', function(done) {
+
+          var criteria = {
+            where: {
+              field_2: {
+                endsWith: 'AR)H$daxx'
+              }
+            }
+          };
+
+          adapter.find('test', 'test_find', criteria, function(err, results) {
+            results.length.should.eql(1);
+            results[0].field_2.should.eql('AR)H$daxx');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+});

--- a/test/unit/adapter.groupBy.js
+++ b/test/unit/adapter.groupBy.js
@@ -1,0 +1,60 @@
+var Sequel = require('waterline-sequel'),
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * groupBy
+   *
+   * Adds a Group By statement to a sql statement
+   */
+
+  describe('.groupBy()', function() {
+
+    describe('with array', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        groupBy: ['name'],
+        average: ['age']
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should append a Group By clause to the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT "test"."name", CAST( AVG("test"."age") AS float) AS age ' +
+                  'FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  GROUP BY "test"."name"';
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+    describe('with string', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        groupBy: 'name',
+        average: 'age'
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the MAX aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT "test"."name", CAST( AVG("test"."age") AS float) AS age ' +
+                  'FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  GROUP BY "test"."name"'
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.index.js
+++ b/test/unit/adapter.index.js
@@ -1,0 +1,52 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Teardown
+   */
+
+  before(function(done) {
+    support.registerConnection(['test_index'], done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_index', done);
+  });
+
+  // Attributes for the test table
+  var definition = {
+    id: {
+      type: 'integer',
+      autoIncrement: true
+    },
+    name: {
+      type: 'string',
+      index: true
+    }
+  };
+
+  /**
+   * Indexes
+   *
+   * Ensure Indexes get created correctly
+   */
+
+  describe('Index Attributes', function() {
+
+    // Build Indicies from definition
+    it('should add indicies', function(done) {
+
+      adapter.define('test', 'test_index', definition, function(err) {
+        adapter.describe('test', 'test_index', function(err, result) {
+          result.name.indexed.should.eql(true);
+          done();
+        });
+      });
+
+    });
+
+  });
+});

--- a/test/unit/adapter.joins.js
+++ b/test/unit/adapter.joins.js
@@ -1,0 +1,97 @@
+var Sequel = require('waterline-sequel'),
+    _ = require('lodash'),
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * Joins
+   *
+   * Build up SQL queries using joins and subqueries.
+   */
+
+  describe('.joins()', function() {
+
+    var petSchema = {
+      name: 'string',
+      id: {
+        type: 'integer',
+        autoIncrement: true,
+        primaryKey: true,
+        unique: true
+      },
+      createdAt: { type: 'datetime', default: 'NOW' },
+      updatedAt: { type: 'datetime', default: 'NOW' },
+      owner: {
+        columnName: 'owner_id',
+        type: 'integer',
+        foreignKey: true,
+        references: 'user',
+        on: 'id',
+        onKey: 'id'
+      }
+    };
+
+    var userSchema = {
+      name: 'string',
+      id: {
+        type: 'integer',
+        autoIncrement: true,
+        primaryKey: true,
+        unique: true
+      },
+      createdAt: { type: 'datetime', default: 'NOW' },
+      updatedAt: { type: 'datetime', default: 'NOW' },
+      pets: {
+        collection: 'pet',
+        via: 'user',
+        references: 'pet',
+        on: 'owner_id',
+        onKey: 'user'
+      }
+    };
+
+    // Simple populate criteria, ex: .populate('pets')
+    describe('populates', function() {
+
+      // Lookup criteria
+      var criteria =  {
+        instructions: {
+          pet: {
+            strategy: {strategy: 1, meta: { parentFK: 'id' }},
+            instructions: [
+             { parent: 'user',
+               parentKey: 'id',
+               child: 'pet',
+               childKey: 'owner',
+               select: [ 'name', 'id', 'createdAt', 'updatedAt', 'owner' ],
+               alias: 'pet',
+               removeParentKey: true,
+               model: true,
+               collection: false,
+               criteria: {}
+              }
+            ]
+          }
+        },
+        where: null,
+        limit: 30,
+        skip: 0
+      };
+
+      var schemaDef = {'user': Support.Schema('user', userSchema), 'pet': Support.Schema('pet', petSchema)};
+
+      it('should build a query using inner joins', function() {
+        var query = new Sequel(schemaDef, Support.SqlOptions).find('user', criteria);
+        var sql = 'SELECT "user"."name", "user"."id", "user"."createdAt", "user"."updatedAt", '+
+                  '"__pet"."name" AS "id___name", "__pet"."id" AS "id___id", "__pet"."createdAt" ' +
+                  'AS "id___createdAt", "__pet"."updatedAt" AS "id___updatedAt", "__pet"."owner_id" ' + 
+                  'AS "id___owner_id" FROM "user" AS "user"  LEFT OUTER JOIN "pet" AS "__pet" ON ' +
+                  '"user".\"id\" = \"__pet\".\"owner\"  LIMIT 30 OFFSET 0';
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.max.js
+++ b/test/unit/adapter.max.js
@@ -1,0 +1,54 @@
+var Sequel = require('waterline-sequel'), 
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * MAX
+   *
+   * Adds a MAX select parameter to a sql statement
+   */
+
+  describe('.max()', function() {
+
+    describe('with array', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        max: ['age']
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the max aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT MAX("test"."age") AS age FROM "test" AS "test"  WHERE LOWER("test"."name") = $1 ';
+        query.query[0].should.eql(sql);
+      });
+    });
+
+    describe('with string', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        max: 'age'
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the MAX aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT MAX("test"."age") AS age FROM "test" AS "test"  WHERE LOWER("test"."name") = $1 ';
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.min.js
+++ b/test/unit/adapter.min.js
@@ -1,0 +1,54 @@
+var Sequel = require('waterline-sequel'), 
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * MIN
+   *
+   * Adds a MIN select parameter to a sql statement
+   */
+
+  describe('.min()', function() {
+
+    describe('with array', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        min: ['age']
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the min aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT MIN("test"."age") AS age FROM "test" AS "test"  WHERE LOWER("test"."name") = $1 ';
+        query.query[0].should.eql(sql);
+      });
+    });
+
+    describe('with string', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        min: 'age'
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the MIN aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT MIN("test"."age") AS age FROM "test" AS "test"  WHERE LOWER("test"."name") = $1 ';
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.removeAttribute.js
+++ b/test/unit/adapter.removeAttribute.js
@@ -1,0 +1,45 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_removeAttribute', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_removeAttribute', done);
+  });
+
+  /**
+   * REMOVE ATTRIBUTE
+   *
+   * Drops a Column from a Table
+   */
+
+  describe('.removeAttribute()', function() {
+
+    // Remove a column to a table
+    it('should remove column field_2 from the table', function(done) {
+
+      adapter.removeAttribute('test', 'test_removeAttribute', 'field_2', function(err) {
+        adapter.describe('test', 'test_removeAttribute', function(err, result) {
+
+          // Test Row length
+          Object.keys(result).length.should.eql(2);
+
+          // Test the name of the last column
+          should.not.exist(result.field_2);
+
+          done();
+        });
+      });
+
+    });
+  });
+});

--- a/test/unit/adapter.sum.js
+++ b/test/unit/adapter.sum.js
@@ -1,0 +1,58 @@
+var Sequel = require('waterline-sequel'), 
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * SUM
+   *
+   * Adds a SUM select parameter to a sql statement
+   */
+
+  describe('.sum()', function() {
+
+    describe('with array', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sum: ['age']
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the SUM aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT CAST(SUM("test"."age") AS float) AS age FROM "test" AS "test"  WHERE ' +
+                  'LOWER("test"."name") = $1 ';
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+    describe('with string', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sum: 'age'
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should use the SUM aggregate option in the select statement', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT CAST(SUM("test"."age") AS float) AS age FROM "test" AS "test"  WHERE ' +
+                  'LOWER("test"."name") = $1 ';
+
+        query.query[0].should.eql(sql);
+      });
+    });
+
+  });
+});

--- a/test/unit/adapter.update.js
+++ b/test/unit/adapter.update.js
@@ -1,0 +1,53 @@
+var adapter = require('../../lib/adapter'),
+    should = require('should'),
+    support = require('./support/bootstrap');
+
+describe('adapter', function() {
+
+  /**
+   * Setup and Teardown
+   */
+
+  before(function(done) {
+    support.Setup('test_update', done);
+  });
+
+  after(function(done) {
+    support.Teardown('test_update', done);
+  });
+
+  /**
+   * UPDATE
+   *
+   * Update a row in a table
+   */
+
+  describe('.update()', function() {
+
+    describe('with options', function() {
+
+      before(function(done) {
+        support.Seed('test_update', done);
+      });
+
+      it('should update the record', function(done) {
+
+        adapter.update('test', 'test_update', { where: { id: 1 }}, { field_1: 'foobar' }, function(err, result) {
+          result[0].field_1.should.eql('foobar');
+          done();
+        });
+
+      });
+
+      it('should keep case', function(done) {
+
+        adapter.update('test', 'test_update', { where: { id: 1 }}, { field_1: 'FooBar' }, function(err, result) {
+          result[0].field_1.should.eql('FooBar');
+          done();
+        });
+
+      });
+
+    });
+  });
+});

--- a/test/unit/query.skip.js
+++ b/test/unit/query.skip.js
@@ -1,0 +1,32 @@
+var Sequel = require('waterline-sequel'),
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * SKIP
+   *
+   * Adds an OFFSET parameter to a sql statement
+   */
+
+  describe('.skip()', function() {
+
+    // Lookup criteria
+    var criteria = {
+      where: {
+        name: 'foo'
+      },
+      skip: 1
+    };
+
+    var schema = {'test': Support.Schema('test', { name: { type: 'text' } })};
+
+    it('should append the SKIP clause to the query', function() {
+      var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+      var sql = 'SELECT "test"."name" FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  LIMIT 184467440737095516  OFFSET 1';
+      query.query[0].should.eql(sql);
+    });
+
+  });
+});

--- a/test/unit/query.sort.js
+++ b/test/unit/query.sort.js
@@ -1,0 +1,81 @@
+var Sequel = require('waterline-sequel'), 
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * SORT
+   *
+   * Adds an ORDER BY parameter to a sql statement
+   */
+
+  describe('.sort()', function() {
+
+    it('should append the ORDER BY clause to the query', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sort: {
+          name: 1
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' } })};
+
+      var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+      var sql = 'SELECT "test"."name" FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  ' +
+                'ORDER BY "test"."name" ASC';
+
+      query.query[0].should.eql(sql);
+    });
+
+    it('should sort by multiple columns', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sort: {
+          name: 1,
+          age: 1
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+      var sql = 'SELECT "test"."name", "test"."age" FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  ' +
+                'ORDER BY "test"."name" ASC, "test"."age" ASC';
+
+      query.query[0].should.eql(sql);
+    });
+
+    it('should allow desc and asc ordering', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: 'foo'
+        },
+        sort: {
+          name: 1,
+          age: -1
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+      var sql = 'SELECT "test"."name", "test"."age" FROM "test" AS "test"  WHERE LOWER("test"."name") = $1  ' +
+                'ORDER BY "test"."name" ASC, "test"."age" DESC';
+
+      query.query[0].should.eql(sql);
+    });
+
+  });
+});

--- a/test/unit/query.where.js
+++ b/test/unit/query.where.js
@@ -1,0 +1,209 @@
+var Sequel = require('waterline-sequel'),
+    should = require('should'),
+    Support = require('./support/bootstrap');
+
+describe('query', function() {
+
+  /**
+   * WHERE
+   *
+   * Build the WHERE part of an sql statement from a js object
+   */
+
+  describe('.where()', function() {
+
+    describe('`AND` criteria', function() {
+
+      describe('case insensitivity', function() {
+
+        // Lookup criteria
+        var criteria = {
+          where: {
+            name: 'Foo',
+            age: 1
+          }
+        };
+
+        var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+        it('should build a SELECT statement using LOWER() on strings', function() {
+          var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+          var sql = 'SELECT "test"."name", "test"."age" FROM "test" AS "test"  ' +
+                    'WHERE LOWER("test"."name") = $1 AND "test"."age" = $2 ';
+
+          query.query[0].should.eql(sql);
+          query.values[0][0].should.eql('foo');
+          query.values[0][1].should.eql(1);
+        });
+      });
+
+      describe('criteria is simple key value lookups', function() {
+
+        // Lookup criteria
+        var criteria = {
+          where: {
+            name: 'foo',
+            age: 27
+          }
+        };
+
+        var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+        it('should build a simple SELECT statement', function() {
+          var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+          var sql = 'SELECT "test"."name", "test"."age" FROM "test" AS "test"  ' +
+                    'WHERE LOWER("test"."name") = $1 AND "test"."age" = $2 ';
+
+          query.query[0].should.eql(sql);
+          query.values[0].length.should.eql(2);
+        });
+
+      });
+
+      describe('has multiple comparators', function() {
+
+        // Lookup criteria
+        var criteria = {
+          where: {
+            name: 'foo',
+            age: {
+              '>' : 27,
+              '<' : 30
+            }
+          }
+        };
+
+        var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+        it('should build a SELECT statement with comparators', function() {
+          var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+          var sql = 'SELECT "test"."name", "test"."age" FROM "test" AS "test"  ' +
+                    'WHERE LOWER("test"."name") = $1 AND "test"."age" > $2 AND "test"."age" < $3  ';
+
+          query.query[0].should.eql(sql);
+          query.values[0].length.should.eql(3);
+        });
+
+      });
+    });
+
+    describe('`LIKE` criteria', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          like: {
+            type: '%foo%',
+            name: 'bar%'
+          }
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, type: { type: 'text' } })};
+
+      it('should build a SELECT statement with ILIKE', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+        var sql = 'SELECT "test"."name", "test"."type" FROM "test" AS "test"  WHERE LOWER("test"."type") ILIKE $1 ' +
+                  'AND LOWER("test"."name") ILIKE $2 ';
+
+        query.query[0].should.eql(sql);
+        query.values[0].length.should.eql(2);
+      });
+
+    });
+
+    describe('`OR` criteria', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          or: [
+            { like: { foo: '%foo%' } },
+            { like: { bar: '%bar%' } }
+          ]
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { foo: { type: 'text' }, bar: { type: 'text'} })};
+
+      it('should build a SELECT statement with multiple like statements', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+        var sql = 'SELECT "test"."foo", "test"."bar" FROM "test" AS "test"  WHERE ((LOWER("test"."foo") ILIKE $1) ' +
+                  'OR (LOWER("test"."bar") ILIKE $2)) ';
+
+        query.query[0].should.eql(sql);
+        query.values[0].length.should.eql(2);
+      });
+    });
+
+    describe('`IN` criteria', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          name: [
+            'foo',
+            'bar',
+            'baz'
+          ]
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, myId: { type: 'integer'} })};
+
+      var camelCaseCriteria = {
+        where: {
+          myId: [
+            1,
+            2,
+            3
+          ]
+        }
+      };
+
+      it('should build a SELECT statement with an IN array', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+        var sql = 'SELECT "test"."name", "test"."myId" FROM "test" AS "test"  WHERE LOWER("test"."name") IN ($1,$2,$3) ';
+
+        query.query[0].should.eql(sql);
+        query.values[0].length.should.eql(3);
+      });
+
+      it('should build a SELECT statememnt with an IN array and camel case column', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', camelCaseCriteria);
+
+        query.query[0].should.eql('SELECT "test"."name", "test"."myId" FROM "test" AS "test"  WHERE "test"."myId" IN ($1,$2,$3) ');
+        query.values[0].length.should.eql(3);
+      });
+
+    });
+
+    describe('`NOT` criteria', function() {
+
+      // Lookup criteria
+      var criteria = {
+        where: {
+          age: {
+            not: 40
+          }
+        }
+      };
+
+      var schema = {'test': Support.Schema('test', { name: { type: 'text' }, age: { type: 'integer'} })};
+
+      it('should build a SELECT statement with an NOT clause', function() {
+        var query = new Sequel(schema, Support.SqlOptions).find('test', criteria);
+
+        query.query[0].should.eql('SELECT "test"."name", "test"."age" FROM "test" AS "test"  WHERE "test"."age" <> $1  ');
+        query.values[0].length.should.eql(1);
+      });
+
+    });
+
+  });
+});

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -16,7 +16,7 @@ Support.SqlOptions = {
 
 Support.Config = {
   host: 'localhost',
-  user: process.env.DB_USER || 'sixpounder',
+  user: process.env.DB_USER || 'root',
   password: process.env.DB_PASS || '',
   database: 'sails_unitTest',
   port: 3306

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -18,7 +18,7 @@ Support.Config = {
   host: 'localhost',
   user: process.env.DB_USER || 'root',
   password: process.env.DB_PASS || '',
-  database: 'sails_unitTest',
+  database: 'sails_mysql',
   port: 3306
 };
 

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -1,0 +1,145 @@
+var mysql = require('mysql'),
+    _ = require('lodash'),
+    adapter = require('../../../lib/adapter');
+
+var Support = module.exports = {};
+
+Support.SqlOptions = {
+  parameterized: true,
+  caseSensitive: true,
+  escapeCharacter: '"',
+  casting: true,
+  canReturnValues: true,
+  escapeInserts: true,
+  declareDeleteAlias: false
+};
+
+Support.Config = {
+  host: 'localhost',
+  user: process.env.DB_USER || 'sixpounder',
+  password: process.env.DB_PASS || '',
+  database: 'sails_unitTest',
+  port: 3306
+};
+
+// Fixture Collection Def
+Support.Collection = function(name, def) {
+  var schemaDef = {};
+  schemaDef[name] = Support.Schema(name, def);
+  return {
+    identity: name,
+    tableName: name,
+    connection: 'test',
+    definition: def || Support.Definition,
+    waterline: { schema: schemaDef }
+  };
+};
+
+// Fixture Table Definition
+Support.Definition = {
+  field_1: { type: 'string' },
+  field_2: { type: 'string' },
+  id: {
+    type: 'integer',
+    autoIncrement: true,
+    size: 64,
+    primaryKey: true
+  }
+};
+
+Support.Schema = function(name, def) {
+  return {
+    connection: 'test',
+    identity: name,
+    tableName: name,
+    attributes: def || Support.Definition
+  };
+}
+
+// Register and Define a Collection
+Support.Setup = function(tableName, cb) {
+
+  var collection = Support.Collection(tableName);
+
+  var collections = {};
+  collections[tableName] = collection;
+
+  var connection = _.cloneDeep(Support.Config);
+  connection.identity = 'test';
+
+  adapter.registerConnection(connection, collections, function(err) {
+    if(err) return cb(err);
+    adapter.define('test', tableName, Support.Definition, function(err) {
+      if(err) return cb(err);
+      cb();
+    });
+  });
+};
+
+// Just register a connection
+Support.registerConnection = function(tableNames, cb) {
+  var collections = {};
+
+  tableNames.forEach(function(name) {
+    var collection = Support.Collection(name);
+    collections[name] = collection;
+  });
+
+  var connection = _.cloneDeep(Support.Config);
+  connection.identity = 'test';
+
+  adapter.registerConnection(connection, collections, cb);
+};
+
+// Remove a table
+Support.Teardown = function(tableName, cb) {
+  var client = mysql.createConnection(this.Config);
+  
+  dropTable(tableName, client, function(err) {
+    if(err) {
+      return cb(err);
+    }
+    
+    adapter.teardown('test', function(err) {
+      cb();
+    });
+    
+  });
+};
+
+// Return a client used for testing
+Support.Client = function(cb) {
+  var connection = mysql.createConnection(this.Config);
+  connection.connect(function(err) {
+    if(err) { cb(err); }
+    cb(null, connection);
+  });
+};
+
+// Seed a record to use for testing
+Support.Seed = function(tableName, cb) {
+  this.Client(function(err, client) {
+    createRecord(tableName, client, function(err) {
+      if(err) {
+        return cb(err);
+      }
+      cb();
+    });
+  });
+};
+
+function dropTable(table, client, cb) {
+  client.connect();
+
+  var query = "DROP TABLE " + table + ';';
+  client.query(query, cb);
+}
+
+function createRecord(table, client, cb) {
+  var query = [
+  "INSERT INTO " + table + " (field_1, field_2) " +
+  "values ('foo', 'bar');"
+  ].join('');
+
+  client.query(query, cb);
+}


### PR DESCRIPTION
Added support for BIGINT, TINYINT and SMALLINT using the 'size' model attribute key to determine which sql type is needed. 

No MEDIUMINT supported because as far as I know MEDIUMINTs get internally promoted to INTs.

Initially tested against latest stable waterline/sails release. 