### PR TITLE
Standardise query logging.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -27,10 +27,10 @@ var STRINGFILE = {
 };
 
 // Hack for development - in future versions, allow
-// string queries to be elegantly displayed (see wl2
+// logger to be injected (see wl2
 // or tweet @mikermcneil for status of this feature or
 // to help out)
-var LOG_QUERIES = process.env.LOG_QUERIES === 'true';
+var log = (process.env.LOG_QUERIES === 'true') ? console.log : function () {};
 
 module.exports = (function() {
 
@@ -100,6 +100,8 @@ module.exports = (function() {
       function __QUERY__(connection, cb) {
 
         // Run query
+        log('MySQL.query: ', query);
+
         if (data) connection.query(query, data, cb);
         else connection.query(query, cb);
 
@@ -130,10 +132,9 @@ module.exports = (function() {
         var pkQuery = 'SHOW INDEX FROM ' + tableName;
 
         // Run query
-        if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',query);
-          console.log('and: ',pkQuery);
-        }
+        log('MySQL.describe: ', query);
+        log('MySQL.describe(pk): ', pkQuery);
+
         connection.query(query, function __DESCRIBE__(err, schema) {
           if (err) {
             if (err.code === 'ER_NO_SUCH_TABLE') {
@@ -221,9 +222,8 @@ module.exports = (function() {
 
 
         // Run query
-        if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',query);
-        }
+        log('MYSQL.define: ', query);
+
         connection.query(query, function __DEFINE__(err, result) {
           if (err) return cb(err);
 
@@ -269,11 +269,9 @@ module.exports = (function() {
           // Build query
           var query = 'DROP TABLE ' + tableName;
 
-          if (LOG_QUERIES) {
-            console.log('\nExecuting MySQL query: ',query);
-          }
-
           // Run query
+          log('MYSQL.drop: ', query);
+
           connection.query(query, function __DROP__(err, result) {
             if (err) {
               if (err.code !== 'ER_BAD_TABLE_ERROR' && err.code !== 'ER_NO_SUCH_TABLE') return next(err);
@@ -310,11 +308,8 @@ module.exports = (function() {
         var query = sql.addColumn(tableName, attrName, attrDef);
 
         // Run query
-        if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',query);
-        }
+        log('MYSQL.addAttribute: ', query);
 
-        // Run query
         connection.query(query, function(err, result) {
           if (err) return cb(err);
 
@@ -342,11 +337,9 @@ module.exports = (function() {
 
         var query = sql.removeColumn(tableName, attrName);
 
-        if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',query);
-        }
-
         // Run query
+        log('MYSQL.removeAttribute: ', query);
+
         connection.query(query, function(err, result) {
           if (err) return cb(err);
 
@@ -396,6 +389,8 @@ module.exports = (function() {
         }
 
         // Run query
+        log('MySQL.create: ', _query.query);
+
         connection.query(_query.query, function(err, result) {
           if (err) return cb( handleQueryError(err) );
 
@@ -458,6 +453,8 @@ module.exports = (function() {
           }
 
           // Run query
+          log('MySQL.createEach: ', _query.query);
+
           connection.query(_query.query, function(err, results) {
             if (err) return cb( handleQueryError(err) );
             records.push(results.insertId);
@@ -483,9 +480,8 @@ module.exports = (function() {
           var query = 'SELECT * FROM ' + mysql.escapeId(tableName) + ' WHERE ' + mysql.escapeId(pk) + ' IN (' + records + ');';
 
           // Run Query returing results
-          if (LOG_QUERIES) {
-            console.log('\ncreateEach() :: Executing MySQL query: ',query);
-          }
+          log('MYSQL.createEach: ', query);
+
           connection.query(query, function(err, results) {
             if(err) return cb(err);
             cb(null, results);
@@ -585,6 +581,8 @@ module.exports = (function() {
             async.auto({
 
               processParent: function(next) {
+                log('MySQL.populateBuffers: ', _query.query[0]);
+
                 client.query(_query.query[0], function __FIND__(err, result) {
                   if(err) return next(err);
 
@@ -734,6 +732,8 @@ module.exports = (function() {
                     }
                   }
 
+                  log('MySQL.processChildren: ', qs);
+
                   client.query(qs, function __FIND__(err, result) {
                     if(err) return next(err);
 
@@ -829,9 +829,7 @@ module.exports = (function() {
         }
 
         // Run query
-        if (LOG_QUERIES) {
-          console.log('\nExecuting MySQL query: ',_query);
-        }
+        log('MYSQL.find: ', _query);
 
         connection.query(_query.query[0], function(err, result) {
           if(err) return cb(err);
@@ -875,6 +873,8 @@ module.exports = (function() {
         var query = sql.countQuery(tableName, options, localSchema);
 
         // Run query
+        log('MySQL.count: ', query);
+
         connection.query(query, function(err, result) {
           if(err) return cb(err);
           // Return the count from the simplified query
@@ -904,6 +904,8 @@ module.exports = (function() {
         var query = sql.selectQuery(tableName, options);
 
         // Run query
+        log('MySQL.stream: ', query);
+
         var dbStream = connection.query(query);
 
         // Handle error, an 'end' event will be emitted after this as well
@@ -958,6 +960,8 @@ module.exports = (function() {
           return cb(e);
         }
 
+        log('MySQL.update(before): ', _query.query[0]);
+
         connection.query(_query.query[0], function(err, results) {
           if(err) return cb(err);
 
@@ -991,6 +995,8 @@ module.exports = (function() {
           }
 
           // Run query
+          log('MySQL.update: ', _query.query);
+
           connection.query(_query.query, function(err, result) {
             if (err) return cb( handleQueryError(err) );
 
@@ -1011,6 +1017,8 @@ module.exports = (function() {
             }
 
             // Run query
+            log('MySQL.update(after): ', _query.query[0]);
+
             connection.query(_query.query[0], function(err, result) {
               if(err) return cb(err);
               cb(null, result);
@@ -1056,6 +1064,8 @@ module.exports = (function() {
           },
 
           destroyRecords: ['findRecords', function(next) {
+            log('MySQL.destroy: ', _query.query);
+
             connection.query(_query.query, next);
           }]
         },

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -829,7 +829,7 @@ module.exports = (function() {
         }
 
         // Run query
-        log('MYSQL.find: ', _query);
+        log('MYSQL.find: ', _query.query[0]);
 
         connection.query(_query.query[0], function(err, result) {
           if(err) return cb(err);


### PR DESCRIPTION
Fixes #173 (not all queries logged)

Logs all queries using a standardised function. In the future, the adapter should be configured to accept a different logging function.

To see, run the tests with `LOG_QUERIES=true`.