### PR TITLE
Allow for fixed-size binary primary key

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -82,10 +82,24 @@ var sql = module.exports = {
     if(attribute.primaryKey) {
 
       // If type is an integer, set auto increment
-      if(type === 'INT') {
+      if (type === 'INT') {
+        
         return attrName + ' INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
       }
-
+      
+      // If type is BLOB, reset to a fixed size BINARY column
+      if (type === 'BLOB') {
+        
+        // Default 16 byte length
+        var size = 16;
+        if (validColumnSize(attr.size)) {
+          
+          size = attr.size;
+        }
+        
+        return attrName + 'BINARY('+ size +') NOT NULL PRIMARY KEY'; 
+      }
+      
       // Just set NOT NULL on other types
       return attrName + ' VARCHAR(255) NOT NULL PRIMARY KEY';
     }
@@ -358,9 +372,11 @@ function sqlTypeCast(attr) {
       var size = 255; // By default.
 
       // If attr.size is positive integer, use it as size of varchar.
-      if(!isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(attr.size) > 0))
+      if(validColumnSize(attr.size)) {
+        
         size = attr.size;
-
+      }
+      
       return 'VARCHAR(' + size + ')';
     }
 
@@ -427,4 +443,10 @@ function validSubAttrCriteria(c) {
   !_.isUndefined(c.greaterThanOrEqual) || !_.isUndefined(c.lessThanOrEqual) || !_.isUndefined(c['<']) ||
   !_.isUndefined(c['<=']) || !_.isUndefined(c['!']) || !_.isUndefined(c['>']) || !_.isUndefined(c['>=']) ||
   !_.isUndefined(c.startsWith) || !_.isUndefined(c.endsWith) || !_.isUndefined(c.contains) || !_.isUndefined(c.like));
+}
+
+function validColumnSize(size) {
+  
+  // Is definitely an integer number greater than zero
+  return !isNaN(size) && (parseInt(size) == parseFloat(size)) && (parseInt(size) > 0);
 }


### PR DESCRIPTION
This allows for a user to define a model with a binary type primary key.  Resolves #215 .  This should be tested before being merged.

CC: @Pakalex @dmarcelino @tjwebb 