### PR TITLE
Enable feature cross-adapter tests 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
       "migratable",
       "associations",
       "sql"
+    ],
+    "features": [
+      "cross-adapter"
     ]
   }
 }

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -23,10 +23,12 @@ var Adapter = require('../../lib/adapter');
 
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {},
-  interfaces = [];
+  interfaces = [],
+  features = [];
 try {
   package = require('../../package.json');
   interfaces = package.waterlineAdapter.interfaces;
+  features = package.waterlineAdapter.features;
 } catch (e) {
   throw new Error(
     '\n' +
@@ -81,6 +83,10 @@ new TestRunner({
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
   interfaces: interfaces,
+  
+  // The set of adapter features to test against.
+  // (grabbed these from this adapter's package.json file above)
+  features: features,
     
   // Return code non zero if any test fails
   failOnError: true


### PR DESCRIPTION
To make use of the new cross-adapter tests introduced by balderdashy/waterline-adapter-tests#64.