### PR TITLE
Check if a custom size for the primary key field is set

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -86,8 +86,13 @@ var sql = module.exports = {
         return attrName + ' INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
       }
 
+      // Check if custom size is set
+      var size = 255;
+      if(!isNaN(attribute.size) && (parseInt(attribute.size) == parseFloat(attribute.size)) && (parseInt(attribute.size) > 0))
+        size = attribute.size;
+
       // Just set NOT NULL on other types
-      return attrName + ' VARCHAR(255) NOT NULL PRIMARY KEY';
+      return attrName + ' VARCHAR(' + size + ') NOT NULL PRIMARY KEY';
     }
 
     // Process NOT NULL field.


### PR DESCRIPTION
The hardcoded value 255 causes problems if we use a database collation that does
not support indices of 255, for instance 'utf8mb4_unicode_ci' (max length 191). This
will cause sails to not load the ORM as the database will throw an error like:

"Error: ER_TOO_LONG_KEY: Specified key was too long; max key length is X bytes"
In the case of mb4 the max length is 767 bytes (191*4).

Note that an issue (#124) was opened about this, but was closed prematurely as this seems to actually be a bug as well :)