### PR TITLE
Support for unsigned int attribute.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -387,25 +387,29 @@ function sqlTypeCast(attr) {
     case 'int':
     case 'integer': {
       var size = 32; // By default
-      
+      var intAttributes = '';
+
       if(!Number.isNaN(attr.size) && (parseInt(attr.size) == parseFloat(attr.size)) && (parseInt(size) > 0)) {
         size = parseInt(attr.size);
       }
       
       // MEDIUMINT gets internally promoted to INT so there is no real benefit
       // using it.
-      
+      if (attr.unsigned && typeof attr.unsigned === 'boolean' && attr.unsigned) {
+        intAttributes = ' UNSIGNED';
+      }
+
       switch (size) {
         case 8:
-          return 'TINYINT';
+          return 'TINYINT' + intAttributes;
         case 16:
-          return 'SMALLINT';
+          return 'SMALLINT' + intAttributes;
         case 32:
-          return 'INT';
+          return 'INT' + intAttributes;
         case 64:
-          return 'BIGINT'
+          return 'BIGINT' + intAttributes;
         default:
-          return 'INT';
+          return 'INT' + intAttributes;
       }
     }
 

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -27,6 +27,11 @@ describe('adapter', function() {
       type: 'string',
       notNull: true
     },
+    score : {
+      type: 'integer',
+      size: 16,
+      unsigned: true
+    },
     email : 'string',
     title : 'string',
     phone : 'string',
@@ -53,7 +58,7 @@ describe('adapter', function() {
 
         adapter.define('test', 'test_define', definition, function(err) {
           adapter.describe('test', 'test_define', function(err, result) {
-            Object.keys(result).length.should.eql(8);
+            Object.keys(result).length.should.eql(9);
             done();
           });
         });
@@ -76,6 +81,20 @@ describe('adapter', function() {
         });
       });
 
+      it('should create an unsigned column', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT * from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = 'sails_mysql' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'score'";
+
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("smallint(5) unsigned");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
     });
     
     it('should add a notNull constraint', function(done) {
@@ -113,7 +132,7 @@ describe('adapter', function() {
 
         adapter.define('test', 'user', definition, function(err) {
           adapter.describe('test', 'user', function(err, result) {
-            Object.keys(result).length.should.eql(8);
+            Object.keys(result).length.should.eql(9);
             done();
           });
         });


### PR DESCRIPTION
Along with support for the different integer types, it would be great if Sails now support unsigned integer type too.

To declare a column as unsigned, simply add `unsigned: true` to its definition, for example:

```js
    score : {
      type: 'integer',
      size: 16, // this declares as SMALLINT
      unsigned: true
    }
```