### PR TITLE
Enabling table-specific encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ module.exports.connections = {
     // OR (explicit sets take precedence)
     module    : 'sails-mysql',
     url       : 'mysql2://USER:PASSWORD@HOST:PORT/DATABASENAME'
-    
+
     // Optional
     charset   : 'utf8',
     collation : 'utf8_swedish_ci'
+    defaultTableCharset   : 'utf8'
+    defaultTableCollation : 'utf8_general_ci'
   }
 };
 ```

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -211,13 +211,19 @@ module.exports = (function() {
         // Build query
         var query = 'CREATE TABLE ' + tableName + ' (' + schema + ')';
 
-        if(connectionObject.config.charset) {
-          query += ' DEFAULT CHARSET ' + connectionObject.config.charset;
+        // Add table-specific encoding, or use default encoding if set
+        if (collection.encoding && collection.encoding.charset) {
+          query += ' DEFAULT CHARSET ' + collection.encoding.charset;
+        } else if (connectionObject.config.defaultTableCharset) {
+          query += ' DEFAULT CHARSET ' + connectionObject.config.defaultTableCharset;
         }
 
-        if(connectionObject.config.collation) {
-          if(!connectionObject.config.charset) query += ' DEFAULT ';
-          query += ' COLLATE ' + connectionObject.config.collation;
+        if (collection.encoding && collection.encoding.collation) {
+          if(!collection.encoding.charset) query += ' DEFAULT ';
+          query += ' COLLATE ' + collection.encoding.collation;
+        } else if (connectionObject.config.defaultTableCollation) {
+          if(!connectionObject.config.defaultTableCharset) query += ' DEFAULT ';
+          query += ' COLLATE ' + connectionObject.config.defaultTableCollation;
         }
 
 


### PR DESCRIPTION
Currently, the adapter applies any encoding information in the connectionObject to all tables in a DB, as well as the DB connection. This is causes problems if not all tables require/indexes are compatible with the same encoding.

My change allows the user to specify on their model the encoding for that model/table. Additionally, I created defaultTableCharset and defaultTableCollation attributes on the connection object. This way, the charset/collation settings are used strictly for the connection encoding, where defaultTable settings are encodings applied to the tables.