### PR TITLE
Adding greater verbosity in the event of a foreign key violation

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1235,6 +1235,10 @@ module.exports = (function() {
           rule: 'unique'
         }];
       }
+    }else if(err.code === 'ER_NO_REFERENCED_ROW_2') {
+	formattedErr = {};
+        formattedErr.code = 'E_FK';
+        formattedErr.invalidAttributes = {};
     }
 
     return formattedErr || err;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1235,10 +1235,18 @@ module.exports = (function() {
           rule: 'unique'
         }];
       }
-    }else if(err.code === 'ER_NO_REFERENCED_ROW_2') {
-	formattedErr = {};
+    } else if(err.code === 'ER_NO_REFERENCED_ROW_2') {
+      var matches = err.message.match(/CONSTRAINT `(.*)` FOREIGN/);
+
+      if(matches && matches.length) {
+        formattedErr = {};
         formattedErr.code = 'E_FK';
         formattedErr.invalidAttributes = {};
+        formattedErr.invalidAttributes['foreign_key'] = [{
+          value: 'Corresponding foreign key not found: ' + matches[1],
+          rule: 'required'
+        }];
+      } 
     }
 
     return formattedErr || err;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1236,14 +1236,14 @@ module.exports = (function() {
         }];
       }
     } else if(err.code === 'ER_NO_REFERENCED_ROW_2') {
-      var matches = err.message.match(/CONSTRAINT `(.*)` FOREIGN/);
-
-      if(matches && matches.length) {
+      var constraintKey = err.message.match(/CONSTRAINT `(.*)` FOREIGN/);
+      var foreignTable = err.message.match(/REFERENCES (.*) ON/);
+      if(constraintKey && constraintKey.length && foreignTable && foreignTable.length) {
         formattedErr = {};
         formattedErr.code = 'E_FK';
         formattedErr.invalidAttributes = {};
-        formattedErr.invalidAttributes['foreign_key'] = [{
-          value: 'Corresponding foreign key not found: ' + matches[1],
+        formattedErr.invalidAttributes[constraintKey[1]] = [{
+          value: 'Corresponding foreign key not found in ' + foreignTable[1],
           rule: 'required'
         }];
       } 


### PR DESCRIPTION
In the event of a foreign key violation, the sails-mysql wrapper will return a more informative error message.