### PR TITLE
Add support for size attribute for float and decimal types.

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -413,10 +413,57 @@ function sqlTypeCast(attr) {
 
     case 'float':
     case 'double':
-      return 'FLOAT';
+      var type = 'FLOAT'; // default
+      
+      if(typeof attr.size === 'string' && attr.size) {
+        var values = attr.size.split(',');
+        
+        if(values.length === 2) { // should always be length 2
+          // Validate values
+          var flag1 = false;
+          var flag2 = false;
+          if(!Number.isNaN(values[0]) && (parseInt(values[0]) == parseFloat(values[0])) && (parseInt(values[0]) > 0)) {
+            var M = values[0];
+            flag1 = true;
+          }
+          if(!Number.isNaN(values[1]) && (parseInt(values[1]) == parseFloat(values[1])) && (parseInt(values[1]) >= 0)) {
+            var D = values[1];
+            flag2 = true;
+          }
+          
+          if(flag1 && flag2) {
+            type = 'FLOAT(' + M + ',' + D  + ')';
+          }
+        }
+      }
+      
+      return type;
     
     case 'decimal':
-      return 'DECIMAL';
+      var type = 'DECIMAL'; // default
+      
+      if(typeof attr.size === 'string' && attr.size) {
+        var values = attr.size.split(',');
+        
+        if(values.length === 2) { // should always be length 2
+          // Validate values
+          var flag1 = false;
+          var flag2 = false;
+          if(!Number.isNaN(values[0]) && (parseInt(values[0]) == parseFloat(values[0])) && (parseInt(values[0]) > 0) && (parseInt(values[0]) <= 65)) {
+            var M = values[0];
+            flag1 = true;
+          }
+          if(!Number.isNaN(values[1]) && (parseInt(values[1]) == parseFloat(values[1])) && (parseInt(values[1]) >= 0)) {
+            var D = values[1];
+            flag2 = true;
+          }
+          if(flag1 && flag2) {
+            type = 'DECIMAL(' + M + ',' + D  + ')';
+          }
+        }
+      }
+      
+      return type;
 
     case 'date':
       return 'DATE';

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -27,6 +27,22 @@ describe('adapter', function() {
       type: 'string',
       notNull: true
     },
+    value : {
+      type: 'float',
+      size: '8,4'
+    },
+    decimal : {
+      type: 'decimal',
+      size: '10,4'
+    },
+    fail : {
+      type: 'float',
+      size: 32
+    },
+    wrong : {
+      type: 'decimal',
+      size: 32
+    },
     email : 'string',
     title : 'string',
     phone : 'string',
@@ -69,6 +85,66 @@ describe('adapter', function() {
 
             client.query(query, function(err, rows) {
               rows[0].COLUMN_TYPE.should.eql("bigint(20)");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+      
+      it('should create a float with length 8,4', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = '" + support.Config.database + "' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'value'";
+
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("float(8,4)");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+      
+      it('should create a decimal with length 10,4', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = '" + support.Config.database + "' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'decimal'";
+
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("decimal(10,4)");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+      
+      it('should create a float with no length', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = '" + support.Config.database + "' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'fail'";
+
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("float");
+              client.end();
+              done();
+            });
+          });
+        });
+      });
+      
+      it('should create a decimal with default length', function(done) {
+        adapter.define('test', 'test_define', definition, function(err) {
+          support.Client(function(err, client) {
+            var query = "SELECT COLUMN_TYPE from information_schema.COLUMNS "+
+              "WHERE TABLE_SCHEMA = '" + support.Config.database + "' AND TABLE_NAME = 'test_define' AND COLUMN_NAME = 'wrong'";
+
+            client.query(query, function(err, rows) {
+              rows[0].COLUMN_TYPE.should.eql("decimal(10,0)");
               client.end();
               done();
             });


### PR DESCRIPTION
I've tested these in this repo with unit tests and it works. However, something I noticed is that even thought in this repo `sails-mysql` DECIMAL support is there. When I test on my local box with sails, every time I set an attribute to type to DECIMAL by the time it reaches sails-mysql/lib/sql.js the type is STRING instead of DECIMAL. Not sure what is going on there.

DECIMAL type is a must for storing monetary values. Not sure why at least from looking at the [docs](sailsjs.org/documentation/concepts/models-and-orm/attributes), it's not supported. Since the floating-point (approximate value) types are FLOAT, REAL, and DOUBLE, which they do some rounding. The fixed-point (exact value) types are INTEGER, SMALLINT, DECIMAL, and NUMERIC