### PR TITLE
Use 'pathname' instead of 'path' when parsing db name from url

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,8 +25,8 @@ utils.parseUrl = function (config) {
   config.host = obj.hostname || config.host;
   config.port = obj.port || config.port;
 
-  if(_.isString(obj.path)) {
-    config.database = obj.path.split("/")[1] || config.database;
+  if(_.isString(obj.pathname)) {
+    config.database = obj.pathname.split("/")[1] || config.database;
   }
 
   if(_.isString(obj.auth)) {


### PR DESCRIPTION
Instead of using `path` for parsing we should use `pathname` which won't include the query string. Fixes #261.