### PR TITLE
add support for raw query streaming

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -897,29 +897,39 @@ module.exports = (function() {
 
       if(_.isUndefined(connection)) {
         return spawnConnection(connectionName, __STREAM__);
-      } else {
+      }
+      else {
         __STREAM__(connection);
       }
 
       function __STREAM__(connection, cb) {
 
-        var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[collectionName];
-        var tableName = collectionName;
+        var query;
+        if(options.where
+        && options.where.id !== undefined
+        && typeof options.where.id === 'string'
+        && /^select.*from.*/i.test(options.where.id) ) query = options.where.id;
+        else {
 
-        // Build find query
-        var schema = connectionObject.schema;
-        var _query;
+          var connectionObject = connections[connectionName];
+          var collection = connectionObject.collections[collectionName];
+          var tableName = collectionName;
+          var _query;
 
-        var sequel = new Sequel(schema, sqlOptions);
+          // Build find query
+          var schema = connectionObject.schema;
 
-        // Build a query for the specific query strategy
-        try {
-          _query = sequel.find(collectionName, options);
-        } catch(e) {
-          return cb(e);
+          var sequel = new Sequel(schema, sqlOptions);
+
+          // Build a query for the specific query strategy
+          try {
+            _query = sequel.find(collectionName, options);
+          }
+          catch(e) {
+            return cb(e);
+          }
+          query = _query.query[0];
         }
-        var query = _query.query[0];
 
         // Run query
         log('MySQL.stream: ', query);


### PR DESCRIPTION
Hi, like some other peoples, i guess, i needed to stream the result of raw queries. 
This pr gives the possibility to perform streaming from raw query by using the where.id criteria if he match the query regex.

I created a temporary adapter for my own usage during this PR or if you don't want to merge it.
https://www.npmjs.com/package/sails-mysql-pillow

Best regards,
Polochon