### PR TITLE
MySQL connection.wlNext.caseSensitive propagates up to waterline-sequel

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -65,7 +65,10 @@ module.exports = (function() {
     defaults: {
       pool: true,
       connectionLimit: 5,
-      waitForConnections: true
+      waitForConnections: true,
+      wlNext: {
+        caseSensitive: false
+      }
     },
 
     escape: function(val) {
@@ -77,7 +80,7 @@ module.exports = (function() {
     },
 
 
-    registerConnection: _registerConnection.configure(connections),
+    registerConnection: _registerConnection.configure(connections, sqlOptions),
     teardown: _teardownConnection.configure(connections),
 
 

--- a/lib/connections/register.js
+++ b/lib/connections/register.js
@@ -101,7 +101,7 @@ module.exports.configure = function ( connections, sqlOptions ) {
     }
 
     // if connection's wlNext.caseSensitive is set, pass it on as sqlOptions
-    if (activeConnection.config.wlNext.caseSensitive) {
+    if (activeConnection.config.wlNext && activeConnection.config.wlNext.caseSensitive) {
       sqlOptions.caseSensitive = true;
       !sqlOptions.wlNext && (sqlOptions.wlNext = {});
       sqlOptions.wlNext.caseSensitive = true;

--- a/lib/connections/register.js
+++ b/lib/connections/register.js
@@ -12,7 +12,7 @@ var utils = require('../utils');
 module.exports = {};
 
 
-module.exports.configure = function ( connections ) {
+module.exports.configure = function ( connections, sqlOptions ) {
 
   /**
    * Register a connection (and the collections assigned to it) with the MySQL adapter.
@@ -98,6 +98,13 @@ module.exports.configure = function ( connections ) {
     // Otherwise, assign some default releaseConnection functionality.
     else {
       activeConnection.connection.releaseConnection = _releaseConnection.poollessly;
+    }
+
+    // if connection's wlNext.caseSensitive is set, pass it on as sqlOptions
+    if (activeConnection.config.wlNext.caseSensitive) {
+      sqlOptions.caseSensitive = true;
+      !sqlOptions.wlNext && (sqlOptions.wlNext = {});
+      sqlOptions.wlNext.caseSensitive = true;
     }
 
     // Done!  The WLConnection (and all of it's collections) have been loaded.


### PR DESCRIPTION
Allow `config/connections.js` to define case-sensitive MySQL queries.

Thanks to @shamasis on https://github.com/postmanlabs/sails-mysql/commit/d8bcd07257a8297619da6270376893e560870742 with a little tweak to keep the connector config same as with sails-postgresql (https://github.com/balderdashy/sails-postgresql/issues/142#issuecomment-88680201) 