### PR TITLE
Use MySQL's concept of NULL when storing the null literal at rest, even when an attribute is type: 'json'.

### DIFF
--- a/helpers/private/query/pre-process-record.js
+++ b/helpers/private/query/pre-process-record.js
@@ -5,18 +5,31 @@
 //  ██║     ██║  ██║███████╗    ██║     ██║  ██║╚██████╔╝╚██████╗███████╗███████║███████║
 //  ╚═╝     ╚═╝  ╚═╝╚══════╝    ╚═╝     ╚═╝  ╚═╝ ╚═════╝  ╚═════╝╚══════╝╚══════╝╚══════╝
 //
-//  ██████╗ ███████╗ ██████╗ ██████╗ ██████╗ ██████╗
-//  ██╔══██╗██╔════╝██╔════╝██╔═══██╗██╔══██╗██╔══██╗
-//  ██████╔╝█████╗  ██║     ██║   ██║██████╔╝██║  ██║
-//  ██╔══██╗██╔══╝  ██║     ██║   ██║██╔══██╗██║  ██║
-//  ██║  ██║███████╗╚██████╗╚██████╔╝██║  ██║██████╔╝
-//  ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═════╝
+//  ██████╗ ███████╗ ██████╗ ██████╗ ██████╗ ██████╗  SSSSSS
+//  ██╔══██╗██╔════╝██╔════╝██╔═══██╗██╔══██╗██╔══██╗ S
+//  ██████╔╝█████╗  ██║     ██║   ██║██████╔╝██║  ██║ SSSSSS
+//  ██╔══██╗██╔══╝  ██║     ██║   ██║██╔══██╗██║  ██║      S
+//  ██║  ██║███████╗╚██████╗╚██████╔╝██║  ██║██████╔╝      S
+//  ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═════╝ SSSSSSS
 //
 
 var _ = require('@sailshq/lodash');
 var utils = require('waterline-utils');
 var eachRecordDeep = utils.eachRecordDeep;
 
+
+
+/**
+ * [exports description]
+ *
+ * TODO: Document this utility
+ *
+ * TODO: change the name of this utility to reflect the fact that its job is
+ * to pre-process new incoming records (plural)
+ *
+ * @param  {[type]} options [description]
+ * @return {[type]}         [description]
+ */
 module.exports = function preProcessRecord(options) {
   //  ╦  ╦╔═╗╦  ╦╔╦╗╔═╗╔╦╗╔═╗  ┌─┐┌─┐┌┬┐┬┌─┐┌┐┌┌─┐
   //  ╚╗╔╝╠═╣║  ║ ║║╠═╣ ║ ║╣   │ │├─┘ │ ││ ││││└─┐
@@ -37,13 +50,23 @@ module.exports = function preProcessRecord(options) {
     throw new Error('Invalid option used in options argument. Missing or invalid orm.');
   }
 
-  // Run all the records through the iterator so that they can be normalized.
+  // Run all the new, incoming records through the iterator so that they can be normalized
+  // with anything adapter-specific before getting written to the database.
   eachRecordDeep(options.records, function iterator(record, WLModel) {
-    // JSON stringify any type of JSON attributes because MySQL can't store JSON.
     _.each(WLModel.definition, function checkAttributes(attrDef, attrName) {
+
+      // JSON stringify the values provided for any `type: 'json'` attributes
+      // because MySQL can't store JSON.
       if (attrDef.type === 'json' && _.has(record, attrName)) {
-        record[attrName] = JSON.stringify(record[attrName]);
-      }
+
+        // Special case: If this is the `null` literal, leave it alone.
+        // But otherwise, stringify it into a JSON string.
+        // (even if it's already a string!)
+        if (!_.isNull(record[attrName])) {
+          record[attrName] = JSON.stringify(record[attrName]);
+        }
+
+      }//>-
 
       // If the attribute is type ref and not a Buffer then don't allow it.
       if (attrDef.type === 'ref' && _.has(record, attrName) && !_.isNull(record[attrName])) {

--- a/helpers/private/query/process-each-record.js
+++ b/helpers/private/query/process-each-record.js
@@ -57,8 +57,16 @@ module.exports = function processEachRecord(options) {
 
       // JSON parse any type of JSON column type
       if (attrVal.type === 'json' && _.has(record, attrName)) {
+
+        // Special case: If it came back as the `null` literal, leave it alone
+        if (_.isNull(record[attrName])) {
+          return;
+        }
+
+        // But otherwise, assume it's a JSON string and try to parse it
         record[attrName] = JSON.parse(record[attrName]);
       }
+
     });
   }, false, options.identity, options.orm);
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "benchmark": "2.1.1",
     "eslint": "3.5.0",
     "mocha": "3.0.2",
-    "waterline-adapter-tests": "^1.0.0-2"
+    "waterline-adapter-tests": "^1.0.0-6"
   },
   "waterlineAdapter": {
     "waterlineVersion": "^0.13.0",


### PR DESCRIPTION
Carve out a special exception for the null literal when running JSON.stringify() on incoming values for type: 'json' attrs, and also when decoding outgoing values w/ JSON.parse().