### PR TITLE
Revert code that defaults to the `utf8mb4` character set.

### DIFF
--- a/helpers/private/schema/build-schema.js
+++ b/helpers/private/schema/build-schema.js
@@ -29,7 +29,7 @@ module.exports = function buildSchema(definition) {
       case '_numbertimestamp':
         return 'BIGINT';
       case '_string':
-        return 'VARCHAR(255) CHARACTER SET utf8mb4';
+        return 'VARCHAR(255)';
       case '_stringkey':
         return 'VARCHAR(255)';
       case '_stringtimestamp':
@@ -37,9 +37,9 @@ module.exports = function buildSchema(definition) {
       case '_boolean':
         return 'BOOLEAN';
       case '_json':
-        return 'LONGTEXT CHARACTER SET utf8mb4';
+        return 'LONGTEXT';
       case '_ref':
-        return 'LONGTEXT CHARACTER SET utf8mb4';
+        return 'LONGTEXT';
 
       // Sensible MySQL-specific defaults for common things folks might try to use.
       // (FUTURE: log warnings suggesting proper usage when any of these synonyms are invoked)


### PR DESCRIPTION
It's good for emoji support, but bad because it means that characters take up 4 bytes instead of 3, so you run into the "index key too long" error a lot quicker.  Instead, we'll document using `columnType` to set whatever random column config you need.

Refs https://github.com/balderdashy/waterline/issues/1487
Refs #346 