### PR TITLE
Option to auto-wrap 'ref' type values in Buffer.from()

### DIFF
--- a/helpers/private/query/pre-process-record.js
+++ b/helpers/private/query/pre-process-record.js
@@ -86,7 +86,15 @@ module.exports = function preProcessRecord(options) {
       if (attrDef.type === 'ref' && _.has(record, columnName) && !_.isNull(record[columnName])) {
         var isBuffer = record[columnName] instanceof Buffer;
         if (!isBuffer) {
-          throw new Error('One of the values being set has an attribute type of `ref` but the value is not a Buffer. This adapter only accepts buffers for type `ref`. If you would like to store other types of data perhaps use type `json`.');
+          if(attrDef.meta && attrDef.meta.autoWrap === true){
+            try {
+              record[columnName] = Buffer.from(record[columnName]);
+            } catch (err){
+              throw new Error("meta.autoWrap was true for a 'ref' type of record, but Buffer.from(recordValue) has failed with the following message: "+err.message);
+            }
+          } else {
+            throw new Error('One of the values being set has an attribute type of `ref` but the value is not a Buffer. This adapter only accepts buffers for type `ref`. You can try adding meta: { autoWrap: true } to attribute definition to try to automatically wrap the value. If you would like to store other types of data perhaps use type `json`.');
+          }
         }
       }
     });


### PR DESCRIPTION
Wrap new values for attributes of type 'ref' in Buffer.from(...), when an optional meta.autoWrap flag is set to true in attribute definition. Activated by adding
```
meta: {
  autoWrap: true
}
```
to attribute definition. This can also be used as a workaround for automigrations currently not working correctly with this value datatype, as well as avoid those annoying data type warning messages.

This should take care of [waterline issue 1497](https://github.com/balderdashy/waterline/issues/1497). At least to a degree (doubt it would work on complex objects). I tested it so far with DATETIME (value: well formed date string), TIMESTAMP (value: `new Date().getTime()`), BINARY (value: binary buffer from png image) and STRING (value: you'll never guess what) mysql data types.

This should be used in conjunction with [mysqljs type casting rules](https://github.com/mysqljs/mysql#type-casting). Currently this setting causes waterline to deliver the object that mysqljs natively returns (though I don't know what the plans for future are regarding this behaviour). So for example if you pass in `new Date()` to your `columnType: 'ref'` attribute, then you will get a Date object in `find()` etc. If you pass in a Buffer, adapter's normal behaviour will be invoked and you'll get your buffer back.