### PR TITLE
Removing auto setting JSON to LONGTEXT

### DIFF
--- a/helpers/private/schema/build-schema.js
+++ b/helpers/private/schema/build-schema.js
@@ -43,8 +43,6 @@ module.exports = function buildSchema(definition) {
 
       // Sensible MySQL-specific defaults for common things folks might try to use.
       // (FUTURE: log warnings suggesting proper usage when any of these synonyms are invoked)
-      case 'json':
-        return 'LONGTEXT';
       case 'varchar':
         return 'VARCHAR(255)';
 


### PR DESCRIPTION
If a user tells the system they want to use columnType JSON, we should allow them to do so. By default, if no columnType is specified, then we default it to LONGTEXT. If a user attempts to use columntype JSON and their system does not support it, that is on them to fix the issue. Other wise, they can always not put a columnType and it will maintain backwards compatibility.