### PR TITLE
Clean up errors described in #4400

### DIFF
--- a/helpers/private/connection/release-connection.js
+++ b/helpers/private/connection/release-connection.js
@@ -37,9 +37,8 @@ module.exports = function releaseConnection(connection, leased, cb) {
       try{
         return cb();
       } catch(e){
-        console.log("lolol->",e)
+        console.log(e)
       }
-
     }
   });
 };

--- a/helpers/private/connection/release-connection.js
+++ b/helpers/private/connection/release-connection.js
@@ -34,7 +34,12 @@ module.exports = function releaseConnection(connection, leased, cb) {
       return cb(new Error('Bad connection when trying to release an active connection.'));
     },
     success: function success() {
-      return cb();
+      try{
+        return cb();
+      } catch(e){
+        console.log("lolol->",e)
+      }
+
     }
   });
 };

--- a/helpers/private/connection/release-connection.js
+++ b/helpers/private/connection/release-connection.js
@@ -37,7 +37,7 @@ module.exports = function releaseConnection(connection, leased, cb) {
       try{
         return cb();
       } catch(e){
-        console.log(e)
+        console.log(e);
       }
     }
   });


### PR DESCRIPTION
https://github.com/balderdashy/sails/issues/4400

Looks like Parley is taking over error reporting, this puts it back to normalcy for traditional callbacks.  I'm putting this PR in knowing full well this may not be the /correct/ solution.  But it's working, so maybe it's a good start? Let me know what you think. 