### PR TITLE
Add 'required' to describe function

### DIFF
--- a/helpers/describe.js
+++ b/helpers/describe.js
@@ -148,6 +148,11 @@ module.exports = require('machine').build({
             if (column.Key === 'UNI') {
               schema[column.Field].unique = true;
             }
+            
+            // Check for nullable
+            if (column.Null === 'NO) {
+              schema[column.Field].required = true
+            }
 
             // If also an integer set auto increment attribute
             if (column.Type === 'int(11)') {


### PR DESCRIPTION
I'm using the standalone version of Waterline along with sails-mysql adapter.

Thus, I'm building my own automigration system and I want to detect differences between my model and the database table. The describe function is perfect for this, except it doesn't output the 'Nullable' option that it receives in the query.

I just added this information to the output of the function.