### PR TITLE
Connection url with special characters

### DIFF
--- a/helpers/register-data-store.js
+++ b/helpers/register-data-store.js
@@ -136,7 +136,12 @@ module.exports = require('machine').build({
       url += inputs.config.host + ':' + port + '/' + inputs.config.database;
       inputs.config.url = url;
     }
-
+    
+    try {
+      new URL(inputs.config.url);
+    } catch (e) {
+      return exits.error(new Error('Invalid connection url: remember to use encodeURIComponent() encode special characters in your connection url'));
+    }
 
     //  ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗  ┌┬┐┌─┐┌┐┌┌─┐┌─┐┌─┐┬─┐
     //  ║  ╠╦╝║╣ ╠═╣ ║ ║╣   │││├─┤│││├─┤│ ┬├┤ ├┬┘


### PR DESCRIPTION
If user write some config with special characters, like password is admin$$test, Url.parse() will output wrong result which used in machinepack-mysql line 225. We need warn people to use encodeURIComponent() to encode the password.
Global URL class added in node v10, I wrote it just let you know here need some warnings, because I don't see the issue page.